### PR TITLE
hotfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
spring data jpa 의존성  추가 후 DB가 존재하지 않아 생기는 에러를 해결하기 위해 h2 DB 의존성 추가